### PR TITLE
fix uncaught exception automatic report

### DIFF
--- a/src/com/joshdholtz/sentry/Sentry.java
+++ b/src/com/joshdholtz/sentry/Sentry.java
@@ -393,13 +393,13 @@ public class Sentry {
 			SentryEventBuilder builder = new SentryEventBuilder(e, SentryEventBuilder.SentryEventLevel.FATAL);
 			if (Sentry.getInstance().captureListener != null) {
 				builder = Sentry.getInstance().captureListener.beforeCapture(builder);
-				
-				if (builder != null) {
-					InternalStorage.getInstance().addRequest(new SentryEventRequest(builder));
-				} else {
-					Log.e(Sentry.TAG, "SentryEventBuilder in uncaughtException is null");
-				}
 			}
+
+            if (builder != null) {
+                InternalStorage.getInstance().addRequest(new SentryEventRequest(builder));
+            } else {
+                Log.e(Sentry.TAG, "SentryEventBuilder in uncaughtException is null");
+            }
 
 			//call original handler  
 			defaultExceptionHandler.uncaughtException(thread, e);  


### PR DESCRIPTION
I fixed that if there is no captureListener set then never make report, now if there is no captureListener set it'll send the default report without extras. I don't know this was normaly, but for me not.
