### PR TITLE
Avoid a memory leak when initializing

### DIFF
--- a/sentry-android/src/main/java/com/joshdholtz/sentry/Sentry.java
+++ b/sentry-android/src/main/java/com/joshdholtz/sentry/Sentry.java
@@ -110,7 +110,7 @@ public class Sentry {
 	}
 
 	public static void init(Context context, String dsn) {
-		Sentry.getInstance().context = context;
+		Sentry.getInstance().context = context.getApplicationContext();
 
 		Uri uri = Uri.parse(dsn);
 


### PR DESCRIPTION
Just in case someone is passing an activity context