### PR TITLE
Make it possible to skip setupUncaughtExceptionHandler.

### DIFF
--- a/sentry-android/src/main/java/com/joshdholtz/sentry/Sentry.java
+++ b/sentry-android/src/main/java/com/joshdholtz/sentry/Sentry.java
@@ -111,6 +111,10 @@ public class Sentry {
 	}
 
 	public static void init(Context context, String dsn) {
+		init(context, dsn, true);
+	}
+
+	public static void init(Context context, String dsn, boolean setupUncaughtExceptionHandler) {
 		Sentry.getInstance().context = context.getApplicationContext();
 
 		Uri uri = Uri.parse(dsn);
@@ -124,7 +128,9 @@ public class Sentry {
 		Sentry.getInstance().packageName = context.getPackageName();
 		Sentry.getInstance().verifySsl = getVerifySsl(dsn);
 
-		Sentry.getInstance().setupUncaughtExceptionHandler();
+		if (setupUncaughtExceptionHandler) {
+			Sentry.getInstance().setupUncaughtExceptionHandler();
+		}
 	}
 	
 	private static int getVerifySsl(String dsn) {


### PR DESCRIPTION
For my use-case I don't want to set the global uncaught exception handler, so I modified init() to take a boolean, and then created a version of init() that passes 'true' automatically to maintain the default behavior.