### PR TITLE
Change SentryEventCaptureListener to an interface

### DIFF
--- a/sentry-android/src/main/java/com/joshdholtz/sentry/Sentry.java
+++ b/sentry-android/src/main/java/com/joshdholtz/sentry/Sentry.java
@@ -652,9 +652,9 @@ public class Sentry {
 		}
 	}
 
-	public abstract static class SentryEventCaptureListener {
+	public interface SentryEventCaptureListener {
 
-		public abstract SentryEventBuilder beforeCapture(SentryEventBuilder builder);
+		SentryEventBuilder beforeCapture(SentryEventBuilder builder);
 
 	}
 	


### PR DESCRIPTION
This is not a backwards compatible change - users of this class will have
to change their code to replace the 'extends' keyword with 'implements'.

Fixes #42