### PR TITLE
Use a regex to match internal packages

### DIFF
--- a/sentry-android/build.gradle
+++ b/sentry-android/build.gradle
@@ -23,6 +23,8 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     provided 'org.jbundle.util.osgi.wrapped:org.jbundle.util.osgi.wrapped.org.apache.http.client:4.1.2'
+    androidTestCompile 'com.google.guava:guava:19.0'
+
 }
 
 ext {

--- a/sentry-android/sentry-android.iml
+++ b/sentry-android/sentry-android.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id=":sentry-android" external.linked.project.path="$MODULE_DIR$" external.root.project.path="$MODULE_DIR$/.." external.system.id="GRADLE" external.system.module.group="com.joshdholtz.sentry" external.system.module.version="1.4.3" type="JAVA_MODULE" version="4">
+<module external.linked.project.id=":sentry-android" external.linked.project.path="$MODULE_DIR$" external.root.project.path="$MODULE_DIR$/.." external.system.id="GRADLE" external.system.module.group="com.joshdholtz.sentry" external.system.module.version="1.4.4" type="JAVA_MODULE" version="4">
   <component name="FacetManager">
     <facet type="android-gradle" name="Android-Gradle">
       <configuration>
@@ -76,26 +76,28 @@
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/java" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/jni" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/rs" isTestSource="true" />
-      <excludeFolder url="file://$MODULE_DIR$/build/docs" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/assets" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/blame" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/bundles" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/classes" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/dependency-cache" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/incremental" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/incremental-safeguard" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/instant-run-support" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/jniLibs" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/lint" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/pre-dexed" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/res" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/rs" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/shaders" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/symbols" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/transforms" />
-      <excludeFolder url="file://$MODULE_DIR$/build/libs" />
       <excludeFolder url="file://$MODULE_DIR$/build/outputs" />
-      <excludeFolder url="file://$MODULE_DIR$/build/poms" />
       <excludeFolder url="file://$MODULE_DIR$/build/tmp" />
     </content>
     <orderEntry type="jdk" jdkName="Android API 23 Platform" jdkType="Android SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="library" exported="" scope="TEST" name="guava-19.0" level="project" />
     <orderEntry type="library" exported="" name="org.jbundle.util.osgi.wrapped.org.apache.http.client-4.1.2" level="project" />
     <orderEntry type="library" exported="" name="org.apache.http.legacy-android-23" level="project" />
   </component>

--- a/sentry-android/src/androidTest/java/com/joshdholtz/sentry/SentryEventBuilderTest.java
+++ b/sentry-android/src/androidTest/java/com/joshdholtz/sentry/SentryEventBuilderTest.java
@@ -1,0 +1,83 @@
+package com.joshdholtz.sentry;
+
+import android.provider.Telephony;
+
+import com.google.common.base.Joiner;
+
+import junit.framework.TestCase;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.regex.Pattern;
+
+public class SentryEventBuilderTest extends TestCase {
+
+    // Since regexes are very hard to read, we build the regex to recognize an internal package
+    // name programatically.
+    // Given a list of packages, return a regex to match them.
+    private String toPackageRegex(String... packages) {
+        return String.format("^(%s)\\..*", Joiner.on("|").join(packages).replace(".", "\\."));
+    }
+
+
+    // Test both sides of in_app
+    public void testStackTraces() throws JSONException {
+        final StackTraceElement internal = new StackTraceElement("com.google.android.gms.Common.Foo", "bar", "Foo.java", 19);
+        {
+            JSONObject json = Sentry.SentryEventBuilder.frameJson(internal);
+            assertEquals(false, json.getBoolean("in_app"));
+            assertEquals(19, json.getInt("lineno"));
+            assertEquals("com.google.android.gms.Common.Foo", json.getString("module"));
+            assertEquals("bar", json.getString("function"));
+            assertEquals("Foo.java", json.getString("filename"));
+        }
+
+        final StackTraceElement user = new StackTraceElement("github.sentry.Common.Foo", "qux", "Foo.scala", 22);
+        {
+            JSONObject json = Sentry.SentryEventBuilder.frameJson(user);
+            assertEquals(true, json.getBoolean("in_app"));
+            assertEquals(22, json.getInt("lineno"));
+            assertEquals("github.sentry.Common.Foo", json.getString("module"));
+            assertEquals("qux", json.getString("function"));
+            assertEquals("Foo.scala", json.getString("filename"));
+        }
+    }
+
+    public void testInternalPackageNameRegex() throws Exception {
+
+        // Test 2 simple cases.
+        assertEquals("^(com\\.example)\\..*", toPackageRegex("com.example"));
+        assertEquals("^(com\\.example\\.www|com\\.example)\\..*", toPackageRegex("com.example.www", "com.example"));
+
+        // Now test the actual list of packages that we want to ensure we keep correct.
+        final String[] internalPackages = {
+                "java",
+                "android",
+                "com.android",
+                "com.google.android",
+                "dalvik.system"};
+        assertEquals(Sentry.SentryEventBuilder.isInternalPackage, toPackageRegex(internalPackages));
+
+
+        final String[] internalClasses = {
+                "java.util.list",
+                "android.build.version",
+                "com.android.calculator",
+                "com.google.android.gms.Location",
+                "dalvik.system.console"
+        };
+        for (String c : internalClasses) {
+            assertTrue(c, c.matches(Sentry.SentryEventBuilder.isInternalPackage));
+        }
+
+        final String[] userClasses= {
+                "sentry.client.stack",
+                "com.example.widget",
+        };
+
+        for (String c : userClasses) {
+            assertFalse(c, c.matches(Sentry.SentryEventBuilder.isInternalPackage));
+        }
+    }
+}


### PR DESCRIPTION
- Use a regex to match internal packages
- Add tests for the regex since it's hard to read a regex
- Add com.google.android to the list of internal packages
- Add filenames to callstack JSON packages

Fixes #65