### PR TITLE
Allow the user to specify a message with exceptions

### DIFF
--- a/sentry-android/src/main/java/com/joshdholtz/sentry/Sentry.java
+++ b/sentry-android/src/main/java/com/joshdholtz/sentry/Sentry.java
@@ -35,10 +35,10 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.TimeZone;
 import java.util.UUID;
-import java.util.regex.Pattern;
 
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManager;
@@ -98,10 +98,8 @@ public class Sentry {
 	private Map<String, Object> contexts = Collections.emptyMap();
 
 	private static final String TAG = "Sentry";
-	private static final String DEFAULT_BASE_URL = "https://app.getsentry.com";
 
 	private Sentry() {
-
 	}
 
 	private static void log(String text) {
@@ -234,14 +232,18 @@ public class Sentry {
 	}
 
 	public static void captureException(Throwable t) {
-		Sentry.captureException(t, SentryEventLevel.ERROR);
+		Sentry.captureException(t, t.getMessage(), SentryEventLevel.ERROR);
 	}
 
-	public static void captureException(Throwable t, SentryEventLevel level) {
+	public static void captureException(Throwable t, String message) {
+		Sentry.captureException(t, message, SentryEventLevel.ERROR);
+	}
+
+	public static void captureException(Throwable t, String message, SentryEventLevel level) {
 		String culprit = getCause(t, t.getMessage());
 
 		Sentry.captureEvent(new SentryEventBuilder()
-		.setMessage(t.getMessage())
+		.setMessage(message)
 		.setCulprit(culprit)
 		.setLevel(level)
 		.setException(t)
@@ -689,7 +691,7 @@ public class Sentry {
 		// dalvik.system.*
 		static final String isInternalPackage = "^(java|android|com\\.android|com\\.google\\.android|dalvik\\.system)\\..*";
 		
-		private final static SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
+		private final static SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss", Locale.US);
 		static {
 			sdf.setTimeZone(TimeZone.getTimeZone("GMT"));
 		}
@@ -700,7 +702,7 @@ public class Sentry {
 			return new JSONObject(event);
 		}
 
-		public static enum SentryEventLevel {
+		public enum SentryEventLevel {
 
 			FATAL("fatal"),
 			ERROR("error"),

--- a/sentry-app/src/main/java/com/joshdholtz/sentryapp/MainActivity.java
+++ b/sentry-app/src/main/java/com/joshdholtz/sentryapp/MainActivity.java
@@ -33,6 +33,14 @@ public class MainActivity extends AppCompatActivity {
         s.length();
     }
 
+    public void onClickCapture(View view) {
+        try {
+            onClickBreak(view);
+        } catch (Exception e) {
+            Sentry.captureException(e, "Exception caught in click handler");
+        }
+    }
+
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
         // Handle action bar item clicks here. The action bar will

--- a/sentry-app/src/main/res/layout/activity_main.xml
+++ b/sentry-app/src/main/res/layout/activity_main.xml
@@ -1,5 +1,6 @@
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools" android:layout_width="match_parent"
+    android:orientation="vertical"
     android:layout_height="match_parent" android:paddingLeft="@dimen/activity_horizontal_margin"
     android:paddingRight="@dimen/activity_horizontal_margin"
     android:paddingTop="@dimen/activity_vertical_margin"
@@ -10,4 +11,9 @@
         android:layout_height="wrap_content"
         android:onClick="onClickBreak" />
 
-</RelativeLayout>
+    <Button android:text="Click to capture"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:onClick="onClickCapture" />
+
+</LinearLayout>


### PR DESCRIPTION
It is often useful to add a string of context along with
and exception. This helps show the user what was happening
when the exception occured.

Use case:

try {
  // network operation to load cats
} catch (HttpException e) {
  Sentry.captureException(e, "Error loading cats");
}