### PR TITLE
Add captureException(Throwable, SentryEventLevel) back.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ public class MainActivity extends Activity {
 
 Version | Changes
 --- | ---
+**1.5.1** | Revert accidental API removal of `captureException(Throwable, SentryEventLevel)`.
 **1.5.0** | Add Breadcrumb support [#70](https://github.com/joshdholtz/Sentry-Android/pull/70).<br/>Add release tracking by default [#78](https://github.com/joshdholtz/Sentry-Android/pull/78).<br/>Add the ability to attach a stack-trace to any event [#81](https://github.com/joshdholtz/Sentry-Android/issues/81).<br/>Use a fixed-size thread-pool for sending events [#80](https://github.com/joshdholtz/Sentry-Android/pull/80).<br/>Make it easier to add a message when capturing an exception [#77](https://github.com/joshdholtz/Sentry-Android/pull/77).<br/>Added helper methods for addExtra and addTag [#74](https://github.com/joshdholtz/Sentry-Android/pull/74).<br/>(thanks to [marcomorain](https://github.com/marcomorain))
 **1.4.4** | Sends up device, app, and OS context by default (thanks to [marcomorain](https://github.com/marcomorain))
 **1.4.3** | Fixes for a Google Play warning and added option to not use crash reporting (thanks to [ZeroStride](https://github.com/ZeroStride))

--- a/sentry-android/build.gradle
+++ b/sentry-android/build.gradle
@@ -5,7 +5,7 @@ plugins {
 apply plugin: 'com.android.library'
 
 
-def SentryAndroidVersion = "1.5.0"
+def SentryAndroidVersion = "1.5.1"
 
 android {
     compileSdkVersion 24

--- a/sentry-android/src/main/java/com/joshdholtz/sentry/Sentry.java
+++ b/sentry-android/src/main/java/com/joshdholtz/sentry/Sentry.java
@@ -277,6 +277,10 @@ public class Sentry {
         Sentry.captureException(t, message, SentryEventLevel.ERROR);
     }
 
+    public static void captureException(Throwable t, SentryEventLevel level) {
+        captureException(t, t.getMessage(), level);
+    }
+
     public static void captureException(Throwable t, String message, SentryEventLevel level) {
         String culprit = getCause(t, t.getMessage());
 


### PR DESCRIPTION
This function was removed in error.

Thanks @tutipeti

Fixes https://github.com/joshdholtz/Sentry-Android/commit/07b84c7146d5c4cb38762a6bd13b2543785493bf#commitcomment-19190580