### PR TITLE
Add isInitialized method

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Version | Changes
 ### Gradle
 Available in jCenter
 ```
-compile 'com.joshdholtz.sentry:sentry-android:1.5.0'
+compile 'com.joshdholtz.sentry:sentry-android:1.5.1'
 ```
 
 ### Manual

--- a/sentry-android/src/main/java/com/joshdholtz/sentry/Sentry.java
+++ b/sentry-android/src/main/java/com/joshdholtz/sentry/Sentry.java
@@ -86,6 +86,7 @@ public class Sentry {
     private final static String sentryVersion = "7";
     private static final int MAX_QUEUE_LENGTH = 50;
     private static final int MAX_BREADCRUMBS = 10;
+    private static boolean isInitialized = false;
 
     public static boolean debug = false;
 
@@ -156,6 +157,12 @@ public class Sentry {
         if (setupUncaughtExceptionHandler) {
             sentry.setupUncaughtExceptionHandler();
         }
+
+        isInitialized = true;
+    }
+
+    public static boolean isInitialized(){
+        return isInitialized;
     }
 
     private static Executor fixedQueueDiscardingExecutor(int queueSize) {


### PR DESCRIPTION
This maybe sound like "not needed" feature but I have simple explanation for this approach.
I use Sentry-Android in library which contains pure java and Android based code. The problem is 
that when using android I want to log some of the behaviours from java code. That works, but when I using java I obviously do not initialize Sentry-Android library properly( I do not have Android context and there is no way to get it) so logging with Sentry-Android fails. Since when I am using java code 
I do not need logging at all, so  I do not initialize and that is this method for. 
I hope it sound reasonable enough :P
