### PR TITLE
Set versionName as visible release info

### DIFF
--- a/sentry-android/src/main/java/com/joshdholtz/sentry/Sentry.java
+++ b/sentry-android/src/main/java/com/joshdholtz/sentry/Sentry.java
@@ -307,7 +307,7 @@ public class Sentry {
         final Sentry sentry = Sentry.getInstance();
         final SentryEventRequest request;
         builder.event.put("contexts", sentry.contexts);
-        builder.setRelease(Integer.toString(sentry.appInfo.versionCode));
+        builder.setRelease(sentry.appInfo.versionName);
         builder.event.put("breadcrumbs", Sentry.getInstance().currentBreadcrumbs());
         if (sentry.captureListener != null) {
 


### PR DESCRIPTION
As discussed in #104, sentry frontend should show the app's `versionName` instead of `versionCode` as release information.

This change simply sets that `versionName` content when populating `SentryEventBuilder` in `Sentry.captureEvent()`
