### PR TITLE
Breadcrumb access is not thread safe

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ table below shows an example of what the data will look like in Sentry.
 
 Version | Changes
 --- | ---
+**1.5.3** | Fix thread-safety bug when serializing breadcrumbs. [#110](https://github.com/joshdholtz/Sentry-Android/issues/110) (thanks to [fab1an](https://github.com/fab1an)).
 **1.5.2** | Send stack-frames to Sentry in the correct order. [#95](https://github.com/joshdholtz/Sentry-Android/pull/95).<br/> Use the [versionName](https://developer.android.com/studio/publish/versioning.html#appversioning), rather than versionCode, as the default value for the release field of events (thanks to [FelixBondarenko](https://github.com/FelixBondarenko)).
 **1.5.1** | Revert accidental API removal of `captureException(Throwable, SentryEventLevel)`.
 **1.5.0** | Add Breadcrumb support [#70](https://github.com/joshdholtz/Sentry-Android/pull/70).<br/>Add release tracking by default [#78](https://github.com/joshdholtz/Sentry-Android/pull/78).<br/>Add the ability to attach a stack-trace to any event [#81](https://github.com/joshdholtz/Sentry-Android/issues/81).<br/>Use a fixed-size thread-pool for sending events [#80](https://github.com/joshdholtz/Sentry-Android/pull/80).<br/>Make it easier to add a message when capturing an exception [#77](https://github.com/joshdholtz/Sentry-Android/pull/77).<br/>Added helper methods for addExtra and addTag [#74](https://github.com/joshdholtz/Sentry-Android/pull/74).<br/>(thanks to [marcomorain](https://github.com/marcomorain))

--- a/sentry-android/build.gradle
+++ b/sentry-android/build.gradle
@@ -5,7 +5,7 @@ plugins {
 apply plugin: 'com.android.library'
 
 
-def SentryAndroidVersion = "1.5.2"
+def SentryAndroidVersion = "1.5.3"
 
 android {
     compileSdkVersion 24


### PR DESCRIPTION
I'm opening this PR to see how to best address #110.

This first commit reduces the impact of concurrent modification exceptions but does nothing to fix the problem.
