### PR TITLE
Remove documentation for call to init with baseUrl

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,14 +190,6 @@ Sentry.setCaptureListener(new SentryEventCaptureListener() {
 
 ```
 
-## Use for self hosted Sentry
-
-### Init with your base url
-``` java
-Sentry.init(this, "http://your-base-url.com" "YOUR-SENTRY-DSN");
-
-```
-
 ## Contact
 
 Email: [josh@rokkincat.com](mailto:josh@rokkincat.com)<br/>


### PR DESCRIPTION
This API isn't available, and the baseUri parsing is done by the Sentry library anyway